### PR TITLE
Change bootstrap2 theme to bootstrap3 theme

### DIFF
--- a/lib/atom-json-editor.coffee
+++ b/lib/atom-json-editor.coffee
@@ -114,8 +114,8 @@ module.exports = AtomJsonEditor =
 
 
     @editor = new JSONEditor @atomJsonEditorView.editorContainer,
-      theme: 'bootstrap2'
-      iconlib: 'bootstrap2'
+      theme: 'bootstrap3'
+      iconlib: 'bootstrap3'
       disable_edit_json: true
 #      disable_properties: true
       remove_empty_properties: true


### PR DESCRIPTION
Provides a visual improvement in the Properties window, which under the "bootstrap2" theme had checkboxes inappropriately placed over the list of properties rather than to the left of them. This fixes #8, and was suggested by @mzmb in the comments for issue #8.